### PR TITLE
fix color scale based on color strategy, change legend label defaults

### DIFF
--- a/demo/src/domino_base/index.js
+++ b/demo/src/domino_base/index.js
@@ -33,8 +33,8 @@ const options = {
   ySortOrder: 'desc',
 
   /* colorField */
-  colorStrategy: 'rank', // ['rank', 'value']
-  colorThreshold: 10,
+  colorStrategy: 'value', // ['rank', 'value']
+  colorThreshold: 50,
   colorDominoHighlighted: '#c20a66',
   colorDominoNormal: '#d9e2e4',
 

--- a/dist/bundle.umd.js
+++ b/dist/bundle.umd.js
@@ -1939,6 +1939,7 @@
     ySortOrder,
     yPaddingOuter,
     yPaddingInner,
+    colorStrategy,
     colorThreshold,
     colorDominoNormal,
     colorDominoHighlighted,
@@ -1967,11 +1968,18 @@
       .paddingInner(yPaddingInner)
       .paddingOuter(yPaddingOuter);
 
-    // colorStrategy
-    const colorScale = threshold =>
-      threshold >= colorThreshold ? colorDominoNormal : colorDominoHighlighted;
+    const colorScaleRankStrat = val =>
+      val >= colorThreshold ? colorDominoNormal : colorDominoHighlighted;
 
-    return { xScale, yScale, colorScale }
+    const colorScaleValueStrat = val =>
+      val >= colorThreshold ? colorDominoHighlighted : colorDominoNormal;
+
+    return {
+      xScale,
+      yScale,
+      colorScale:
+        colorStrategy === 'value' ? colorScaleValueStrat : colorScaleRankStrat,
+    }
   }
 
   function renderYAxis({ chartCore, yScale }) {
@@ -2172,8 +2180,8 @@
       colorDominoHighlighted = '#c20a66',
       colorDominoNormal = '#d9e2e4',
 
-      normalLegendLabel = 'Normal Player',
-      highlightedLegendLabel = 'Best Player',
+      normalLegendLabel = 'Normal',
+      highlightedLegendLabel = 'Highlighted',
 
       searchInputClassNames = '',
     },
@@ -2224,6 +2232,7 @@
       colorThreshold,
       colorDominoNormal,
       colorDominoHighlighted,
+      colorStrategy,
     });
 
     renderYAxis({ chartCore, yScale });

--- a/src/charts/domino_base/render.js
+++ b/src/charts/domino_base/render.js
@@ -115,6 +115,7 @@ function setupScales({
   ySortOrder,
   yPaddingOuter,
   yPaddingInner,
+  colorStrategy,
   colorThreshold,
   colorDominoNormal,
   colorDominoHighlighted,
@@ -143,11 +144,18 @@ function setupScales({
     .paddingInner(yPaddingInner)
     .paddingOuter(yPaddingOuter)
 
-  // colorStrategy
-  const colorScale = threshold =>
-    threshold >= colorThreshold ? colorDominoNormal : colorDominoHighlighted
+  const colorScaleRankStrat = val =>
+    val >= colorThreshold ? colorDominoNormal : colorDominoHighlighted
 
-  return { xScale, yScale, colorScale }
+  const colorScaleValueStrat = val =>
+    val >= colorThreshold ? colorDominoHighlighted : colorDominoNormal
+
+  return {
+    xScale,
+    yScale,
+    colorScale:
+      colorStrategy === 'value' ? colorScaleValueStrat : colorScaleRankStrat,
+  }
 }
 
 function renderYAxis({ chartCore, yScale }) {
@@ -348,8 +356,8 @@ export function renderChart({
     colorDominoHighlighted = '#c20a66',
     colorDominoNormal = '#d9e2e4',
 
-    normalLegendLabel = 'Normal Player',
-    highlightedLegendLabel = 'Best Player',
+    normalLegendLabel = 'Normal',
+    highlightedLegendLabel = 'Highlighted',
 
     searchInputClassNames = '',
   },
@@ -400,6 +408,7 @@ export function renderChart({
     colorThreshold,
     colorDominoNormal,
     colorDominoHighlighted,
+    colorStrategy,
   })
 
   renderYAxis({ chartCore, yScale })


### PR DESCRIPTION
Color strategy `value` wasn't working as expected. It was highlighting dominos below the threshold. So fixed that in this PR.