### PR TITLE
search - mace; suggestions as you type (datalist)

### DIFF
--- a/dist/bundle.umd.js
+++ b/dist/bundle.umd.js
@@ -724,12 +724,31 @@
     searchInputClassNames,
     nameField,
     svg,
+    chartContainerSelector,
+    nameValues,
   }) {
+
+    widgetsLeft
+        .append('datalist')
+        .attr('role', 'datalist')
+        // Assuming that chartContainerSelector will always start with #
+        // i.e. it's always an id selector of the from #id-to-identify-search
+        // TODO add validation
+        .attr('id', `${chartContainerSelector.slice(1)}-search-list`)
+        .html(
+          ___default["default"](nameValues)
+            .uniq()
+            .map(el => `<option>${el}</option>`)
+            .join(''),
+        );
+
     const search = widgetsLeft
       .append('input')
       .attr('type', 'text')
       .attr('class', searchInputClassNames);
-    // TODO: refactor hidden, won't be needed if we add this node
+
+    search.attr('list', `${chartContainerSelector.slice(1)}-search-list`);
+
     search.attr('placeholder', `Find by ${nameField}`);
     search.on('keyup', e => {
       const qstr = e.target.value;
@@ -974,7 +993,9 @@
       widgetsLeft,
       searchInputClassNames,
       nameField,
+      nameValues,
       svg,
+      chartContainerSelector,
     });
 
     setupInitialStateButton$5({

--- a/src/charts/mace/render.js
+++ b/src/charts/mace/render.js
@@ -516,12 +516,34 @@ function setupSearch({
   searchInputClassNames,
   nameField,
   svg,
+  chartContainerSelector,
+  nameValues,
 }) {
+  const enableSearchSuggestions = true
+
+  enableSearchSuggestions &&
+    widgetsLeft
+      .append('datalist')
+      .attr('role', 'datalist')
+      // Assuming that chartContainerSelector will always start with #
+      // i.e. it's always an id selector of the from #id-to-identify-search
+      // TODO add validation
+      .attr('id', `${chartContainerSelector.slice(1)}-search-list`)
+      .html(
+        _(nameValues)
+          .uniq()
+          .map(el => `<option>${el}</option>`)
+          .join(''),
+      )
+
   const search = widgetsLeft
     .append('input')
     .attr('type', 'text')
     .attr('class', searchInputClassNames)
-  // TODO: refactor hidden, won't be needed if we add this node
+
+  enableSearchSuggestions &&
+    search.attr('list', `${chartContainerSelector.slice(1)}-search-list`)
+
   search.attr('placeholder', `Find by ${nameField}`)
   search.on('keyup', e => {
     const qstr = e.target.value
@@ -766,7 +788,9 @@ export function renderChart({
     widgetsLeft,
     searchInputClassNames,
     nameField,
+    nameValues,
     svg,
+    chartContainerSelector,
   })
 
   setupInitialStateButton({


### PR DESCRIPTION
1. Added an internal flag to toggle this feature: `enableSearchSuggestions` (default: `true`)
2.  Assuming that `chartContainerSelector` will always start with #, i.e. it's always an id selector of the from `#id-to-identify-search`. TODO add validation on `chartContainerSelector`?